### PR TITLE
Changed "marathone" to "programming contest"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Competitive-Programing
-My codes to practice to marathones
+My codes to practice to programming contests.


### PR DESCRIPTION
Nobody, when speaking English, calls what we know in Portuguese by "Maratona de Programação", "Programming Marathone". The actual word used specifically for the LeetCode-style competition format is "Contest". It's much more likely that the international community will understand when you say "Programming Contest" than when you say "Programming Marathone".

That said, I did a `grep -rn marathone && grep -rn Marathone` and it looks like only the README needs to be changed (you'll need to change the repository description also, I cannot ask to make the change via a PR, only you can change).